### PR TITLE
Add vers=1.0 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sudo mount.cifs \
 	password=$3DS_PASS,\
 	ip=$3DS_LOCALIP,\
 	servern=$3DS_NAME,\
-	uid=$USER,gid=users,nounix /mnt
+	uid=$USER,gid=users,nounix,vers=1.0 /mnt
 ```
 That command will successfully mount your 3DS's microSD card to `/mnt`. Please note that `sudo` is required.
 


### PR DESCRIPTION
Despite that mount.cifs manpage says that vers=1.0 is supposed to be the default, I had to add it to be able to mount the share.